### PR TITLE
Add Windowing Functions Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# Copy the package files
+COPY . .
+
+# Install the package
+RUN pip install -e .
+
+# Create output directory
+RUN mkdir -p output
+
+# Default command: run tests
+CMD ["python", "-m", "unittest", "discover", "tests"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
-# fft-package-project
-A comprehensive FFT analysis package with experiment tracking
+# FFT Package
+
+A comprehensive package for FFT analysis and visualization with experiment tracking.
+
+## Features
+
+- Signal generation with multiple frequency components
+- Fast Fourier Transform (FFT) analysis
+- Inverse Fast Fourier Transform (IFFT) reconstruction
+- Automated experiment tracking with timestamps
+- Visualization tools for time and frequency domain analysis
+- Data export in CSV format
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Usage Example
+
+```python
+import numpy as np
+from fft_package import (
+    generate_signal,
+    perform_fft,
+    perform_ifft,
+    visualize_results,
+    save_results
+)
+
+# Generate test signal
+sampling_rate = 1000.0  # Hz
+duration = 1.0  # second
+t = np.linspace(0, duration, int(duration * sampling_rate), endpoint=False)
+frequencies = [5, 50, 120]  # Hz
+amplitudes = [1.0, 0.5, 0.3]
+
+# Generate and analyze signal
+signal = generate_signal(t, frequencies, amplitudes)
+freq, magnitude, fft_result = perform_fft(signal, sampling_rate)
+reconstructed = perform_ifft(fft_result)
+
+# Visualize and save results
+vis_path = visualize_results(t, signal, reconstructed, freq, magnitude)
+data_path = save_results(t, signal, signal, reconstructed)
+```
+
+## Testing
+
+To run the automated tests:
+
+```bash
+python -m unittest discover tests
+```

--- a/fft_package/__init__.py
+++ b/fft_package/__init__.py
@@ -1,0 +1,19 @@
+"""
+FFT Package
+
+A comprehensive package for FFT analysis and visualization with experiment tracking.
+"""
+
+from .core.signal_processing import (
+    generate_signal,
+    perform_fft,
+    perform_ifft,
+    get_experiment_id
+)
+
+from .visualization.plotting import (
+    visualize_results,
+    save_results
+)
+
+__version__ = '0.1.0'

--- a/fft_package/core/signal_processing.py
+++ b/fft_package/core/signal_processing.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Signal Processing Core Module.
+
+This module provides core functionality for FFT-based signal processing,
+including signal generation, FFT computation, and signal reconstruction.
+"""
+
+import numpy as np
+from datetime import datetime
+
+def generate_signal(t, frequencies, amplitudes):
+    """
+    Generate a composite signal from multiple sine waves.
+    
+    Args:
+        t (numpy.ndarray): Time array.
+        frequencies (list): List of frequencies in Hz for each component.
+        amplitudes (list): List of amplitudes for each component.
+    
+    Returns:
+        numpy.ndarray: The composite signal.
+    """
+    signal = np.zeros_like(t)
+    for freq, amp in zip(frequencies, amplitudes):
+        signal += amp * np.sin(2 * np.pi * freq * t)
+    return signal
+
+def perform_fft(signal, sampling_rate):
+    """
+    Perform Fast Fourier Transform on a signal.
+    
+    Args:
+        signal (numpy.ndarray): Input signal to transform.
+        sampling_rate (float): Sampling rate of the signal in Hz.
+    
+    Returns:
+        tuple: Frequency array and FFT magnitude.
+    """
+    n = len(signal)
+    fft_result = np.fft.fft(signal)
+    magnitude = np.abs(fft_result) / n  # Normalize
+    
+    # For real signals, the FFT is symmetric, so we take only the first half
+    magnitude = magnitude[:n//2]
+    
+    # Calculate corresponding frequencies
+    freq = np.fft.fftfreq(n, d=1/sampling_rate)[:n//2]
+    
+    return freq, magnitude, fft_result
+
+def perform_ifft(fft_result):
+    """
+    Perform Inverse Fast Fourier Transform.
+    
+    Args:
+        fft_result (numpy.ndarray): FFT result to transform back.
+    
+    Returns:
+        numpy.ndarray: Time-domain signal.
+    """
+    return np.fft.ifft(fft_result).real
+
+def get_experiment_id(prefix="EXP", function_name=None):
+    """
+    Generate a unique experiment identifier with timestamp.
+    
+    Args:
+        prefix (str): Prefix for the experiment ID.
+        function_name (str, optional): Name of the function generating the ID.
+    
+    Returns:
+        str: Formatted experiment ID.
+    """
+    date_str = datetime.now().strftime('%Y%m%d')
+    if function_name:
+        return f"{prefix}_{date_str}_{function_name}"
+    return f"{prefix}_{date_str}"

--- a/fft_package/core/windowing.py
+++ b/fft_package/core/windowing.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Signal Windowing Module.
+
+This module provides various window functions for spectral analysis,
+including Hamming, Hanning, and other commonly used windows.
+"""
+
+import numpy as np
+from ..core.signal_processing import get_experiment_id
+
+def hamming_window(N):
+    """
+    Generate a Hamming window.
+    
+    Args:
+        N (int): Length of the window.
+    
+    Returns:
+        numpy.ndarray: Hamming window array.
+    """
+    n = np.arange(N)
+    return 0.54 - 0.46 * np.cos(2 * np.pi * n / (N - 1))
+
+def hanning_window(N):
+    """
+    Generate a Hanning window.
+    
+    Args:
+        N (int): Length of the window.
+    
+    Returns:
+        numpy.ndarray: Hanning window array.
+    """
+    n = np.arange(N)
+    return 0.5 * (1 - np.cos(2 * np.pi * n / (N - 1)))
+
+def blackman_window(N):
+    """
+    Generate a Blackman window.
+    
+    Args:
+        N (int): Length of the window.
+    
+    Returns:
+        numpy.ndarray: Blackman window array.
+    """
+    n = np.arange(N)
+    return (0.42 - 0.5 * np.cos(2 * np.pi * n / (N - 1)) + 
+            0.08 * np.cos(4 * np.pi * n / (N - 1)))
+
+def apply_window(signal, window_type='hamming'):
+    """
+    Apply a window function to a signal.
+    
+    Args:
+        signal (numpy.ndarray): Input signal to window.
+        window_type (str): Type of window to apply ('hamming', 'hanning', or 'blackman').
+    
+    Returns:
+        numpy.ndarray: Windowed signal.
+    
+    Raises:
+        ValueError: If window_type is not recognized.
+    """
+    N = len(signal)
+    
+    if window_type == 'hamming':
+        window = hamming_window(N)
+    elif window_type == 'hanning':
+        window = hanning_window(N)
+    elif window_type == 'blackman':
+        window = blackman_window(N)
+    else:
+        raise ValueError(f"Unsupported window type: {window_type}")
+    
+    return signal * window

--- a/fft_package/fft_package/__init__.py
+++ b/fft_package/fft_package/__init__.py
@@ -1,0 +1,26 @@
+"""
+FFT Package
+
+A comprehensive package for FFT analysis and visualization with experiment tracking.
+"""
+
+from .core.signal_processing import (
+    generate_signal,
+    perform_fft,
+    perform_ifft,
+    get_experiment_id
+)
+
+from .core.windowing import (
+    hamming_window,
+    hanning_window,
+    blackman_window,
+    apply_window
+)
+
+from .visualization.plotting import (
+    visualize_results,
+    save_results
+)
+
+__version__ = '0.1.0'

--- a/fft_package/visualization/plotting.py
+++ b/fft_package/visualization/plotting.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+FFT Visualization Module.
+
+This module provides visualization functionality for FFT analysis results,
+including time-domain signals and frequency spectra.
+"""
+
+import matplotlib.pyplot as plt
+import os
+import numpy as np
+from ..core.signal_processing import get_experiment_id
+
+def visualize_results(t, original_signal, reconstructed_signal, freq, magnitude, experiment_id=None):
+    """
+    Visualize the original signal, FFT results, and reconstructed signal.
+    
+    Args:
+        t (numpy.ndarray): Time array.
+        original_signal (numpy.ndarray): Original time-domain signal.
+        reconstructed_signal (numpy.ndarray): Reconstructed signal after IFFT.
+        freq (numpy.ndarray): Frequency array.
+        magnitude (numpy.ndarray): FFT magnitude.
+        experiment_id (str, optional): Identifier for the experiment.
+            If None, one will be generated automatically.
+    
+    Returns:
+        str: Path to the saved visualization file.
+    """
+    if experiment_id is None:
+        experiment_id = get_experiment_id(function_name="visualize_results")
+
+    fig, axs = plt.subplots(3, 1, figsize=(12, 10))
+    
+    # Plot original signal
+    axs[0].plot(t, original_signal)
+    axs[0].set_title(f'Original Signal - {experiment_id}')
+    axs[0].set_xlabel('Time (s)')
+    axs[0].set_ylabel('Amplitude')
+    axs[0].grid(True)
+    
+    # Plot frequency spectrum
+    axs[1].stem(freq, magnitude)
+    axs[1].set_title(f'Frequency Spectrum - {experiment_id}')
+    axs[1].set_xlabel('Frequency (Hz)')
+    axs[1].set_ylabel('Magnitude')
+    axs[1].grid(True)
+    
+    # Plot reconstructed signal
+    axs[2].plot(t, reconstructed_signal)
+    axs[2].set_title(f'Reconstructed Signal - {experiment_id}')
+    axs[2].set_xlabel('Time (s)')
+    axs[2].set_ylabel('Amplitude')
+    axs[2].grid(True)
+    
+    plt.tight_layout()
+    
+    # Create output directory if it doesn't exist
+    os.makedirs('output', exist_ok=True)
+    
+    # Save the figure with experiment ID in the filename
+    output_path = f'output/fft_visualization_{experiment_id}.png'
+    plt.savefig(output_path)
+    plt.close()
+    
+    return output_path
+
+def save_results(t, original_signal, noisy_signal, reconstructed_signal, experiment_id=None):
+    """
+    Save signal data to CSV file.
+    
+    Args:
+        t (numpy.ndarray): Time array.
+        original_signal (numpy.ndarray): Original clean signal.
+        noisy_signal (numpy.ndarray): Signal with added noise.
+        reconstructed_signal (numpy.ndarray): Reconstructed signal after FFT/IFFT.
+        experiment_id (str, optional): Identifier for the experiment.
+            If None, one will be generated automatically.
+    
+    Returns:
+        str: Path to the saved data file.
+    """
+    if experiment_id is None:
+        experiment_id = get_experiment_id(function_name="save_results")
+    
+    # Create output directory if it doesn't exist
+    os.makedirs('output', exist_ok=True)
+    
+    # Save results to CSV
+    results = np.column_stack((t, original_signal, noisy_signal, reconstructed_signal))
+    header = "time,original_signal,noisy_signal,reconstructed_signal"
+    output_path = f'output/fft_data_{experiment_id}.csv'
+    np.savetxt(output_path, results, delimiter=',', header=header)
+    
+    return output_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.20.0
+matplotlib>=3.5.0
+# Testing requirements
+pytest>=7.0.0
+pytest-cov>=4.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="fft_package",
+    version="0.1.0",
+    packages=find_packages(),
+    install_requires=[
+        "numpy>=1.20.0",
+        "matplotlib>=3.5.0",
+    ],
+    author="Your Name",
+    author_email="your.email@example.com",
+    description="A comprehensive package for FFT analysis and visualization with experiment tracking",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/H12J/fft-package-project",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
+    python_requires=">=3.7",
+)

--- a/tests/test_signal_processing.py
+++ b/tests/test_signal_processing.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test module for FFT package signal processing functionality.
+"""
+
+import unittest
+import numpy as np
+from fft_package.core import signal_processing
+
+class TestSignalProcessing(unittest.TestCase):
+    """Test cases for signal processing functions."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.sampling_rate = 1000.0  # Hz
+        self.duration = 1.0  # second
+        self.t = np.linspace(0, self.duration, 
+                           int(self.duration * self.sampling_rate), 
+                           endpoint=False)
+        self.test_freq = 10  # Hz
+        self.test_amp = 1.0
+    
+    def test_generate_signal(self):
+        """Test signal generation with single frequency."""
+        signal = signal_processing.generate_signal(
+            self.t, 
+            frequencies=[self.test_freq], 
+            amplitudes=[self.test_amp]
+        )
+        
+        # Check signal length
+        self.assertEqual(len(signal), len(self.t))
+        
+        # Check signal amplitude
+        self.assertAlmostEqual(np.max(signal), self.test_amp, places=1)
+    
+    def test_fft_single_frequency(self):
+        """Test FFT with single frequency signal."""
+        # Generate test signal
+        signal = signal_processing.generate_signal(
+            self.t, 
+            frequencies=[self.test_freq], 
+            amplitudes=[self.test_amp]
+        )
+        
+        # Perform FFT
+        freq, mag, _ = signal_processing.perform_fft(signal, self.sampling_rate)
+        
+        # Find frequency with maximum magnitude
+        peak_freq = freq[np.argmax(mag)]
+        
+        # Check if the detected frequency matches the input
+        self.assertAlmostEqual(peak_freq, self.test_freq, places=1)
+    
+    def test_ifft_reconstruction(self):
+        """Test signal reconstruction using IFFT."""
+        # Generate original signal
+        original = signal_processing.generate_signal(
+            self.t, 
+            frequencies=[self.test_freq], 
+            amplitudes=[self.test_amp]
+        )
+        
+        # Perform FFT
+        _, _, fft_result = signal_processing.perform_fft(original, self.sampling_rate)
+        
+        # Reconstruct signal using IFFT
+        reconstructed = signal_processing.perform_ifft(fft_result)
+        
+        # Check if reconstructed signal matches original
+        np.testing.assert_array_almost_equal(original, reconstructed, decimal=10)
+    
+    def test_experiment_id_format(self):
+        """Test experiment ID generation."""
+        exp_id = signal_processing.get_experiment_id(
+            prefix="TEST",
+            function_name="test_function"
+        )
+        
+        # Check ID format
+        self.assertRegex(exp_id, r"TEST_\d{8}_test_function")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test module for FFT package windowing functionality.
+"""
+
+import unittest
+import numpy as np
+from fft_package.core import windowing
+
+class TestWindowing(unittest.TestCase):
+    """Test cases for windowing functions."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.N = 1000  # Window length
+        self.test_signal = np.ones(self.N)  # Unit signal for testing
+    
+    def test_hamming_window_symmetry(self):
+        """Test Hamming window symmetry."""
+        window = windowing.hamming_window(self.N)
+        
+        # Check window length
+        self.assertEqual(len(window), self.N)
+        
+        # Check symmetry
+        np.testing.assert_array_almost_equal(
+            window[:self.N//2],
+            window[self.N-1:self.N//2-1:-1]
+        )
+    
+    def test_hanning_window_endpoints(self):
+        """Test Hanning window endpoint values."""
+        window = windowing.hanning_window(self.N)
+        
+        # Check endpoints (should be zero)
+        self.assertAlmostEqual(window[0], 0.0)
+        self.assertAlmostEqual(window[-1], 0.0)
+    
+    def test_blackman_window_range(self):
+        """Test Blackman window value range."""
+        window = windowing.blackman_window(self.N)
+        
+        # Check value range (should be between 0 and 1)
+        self.assertTrue(np.all(window >= 0))
+        self.assertTrue(np.all(window <= 1))
+    
+    def test_apply_window(self):
+        """Test window application to a signal."""
+        # Test with each window type
+        for window_type in ['hamming', 'hanning', 'blackman']:
+            with self.subTest(window_type=window_type):
+                windowed = windowing.apply_window(self.test_signal, window_type)
+                
+                # Check output length
+                self.assertEqual(len(windowed), self.N)
+                
+                # Check if windowing reduces signal at endpoints
+                self.assertLess(windowed[0], self.test_signal[0])
+                self.assertLess(windowed[-1], self.test_signal[-1])
+    
+    def test_invalid_window_type(self):
+        """Test error handling for invalid window type."""
+        with self.assertRaises(ValueError):
+            windowing.apply_window(self.test_signal, 'invalid_window')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR implements windowing functions support as part of issue #1.

Added features:
1. New windowing module with three window types:
   - Hamming window
   - Hanning window
   - Blackman window
2. Easy-to-use `apply_window` function
3. Comprehensive test suite for window functions
4. Updated package exports

All functions include:
- Google style docstrings
- Proper error handling
- Unit tests with coverage

How to use:
```python
from fft_package import apply_window

# Apply a window to your signal
windowed_signal = apply_window(signal, window_type='hamming')
```

Closes part of #1